### PR TITLE
Added exceptions and reasons

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,12 @@ class MyProtectedClass
 To check if a user has access to a given class / method:
 
 ```php
+try {
 $allowed = $rauth->authorize($classInstanceOrName, $methodName, $attributes);
+} catch (AuthException) {
+    $e->getType(); // will be "ban", "and", "or", etc...
+    $e->getReasons(); // an array of Reason objects with details
+}
 ```
 
 `$attributes` will be an array you build - this depends entirely on your implementation of user attributes. Maybe you're using something like [Gatekeeper](https://github.com/psecio/gatekeeper) and have immediate access to `groups` and/or `permissions` on a `User` entity, and maybe you have a totally custom system. What matters is that you build an array which contains the attributes like so:
@@ -75,16 +80,20 @@ $attributes = [
 
 or maybe something like this:
 
+```php
 $attributes = [
     'permissions' => ['post-write', 'post-read']
 ];
+```
 
 or even something like this:
 
+```php
 $attributes = [
     'groups' => ['admin', 'reg-user'],
     'permissions' => ['post-write', 'post-read']
 ];
+```
 
 You get the drift.
 
@@ -100,7 +109,13 @@ $requirements = [
 ];
 ```
 
-Depending on the mode (see below), Rauth will return either `true` or `false` when you call `authorize()`.
+`authorize` will return `true` if all is well.
+
+If the `authorize` check fails, it will throw an `AuthException`. The `AuthException` will have a `getType` getter which will return a string value of the mode in which the failure happened - be it `ban`, `and`, `or`, `none`, or a custom mode altogether (see modes below). It will also have a `getReasons` getter which provides an array of `Reason` objects. Each object has the following public properties:
+
+- `group`: defines which `@auth-{group}` triggered the exception, e.g. "groups", "permissions", "banana", or whatever else
+- `has`: an array of the attributes provided for that group. If none were provided, empty array.
+- `needs`: an array of attributes needed / prohibited, and compared against `has`.
 
 ### Available Modes
 
@@ -133,10 +148,6 @@ Another option you can use is the `@auth-ban` tag:
 This tag will take precedence if a match is found. So in the example above - if a user is an admin, but is a member of the `blocked` group, they will be denied access. All `ban` matches MUST be zero if the user is to proceed, regardless of all other matches.
 
 > The banhammer wields absolute authority and does not react to `@auth-mode`. Bans must be completely cleared before other permissions are even to be looked at.
-
-## Reason
-
-@todo Figure out how to smoothly implement a reason logger without making the lib heavier
 
 ## Caching
 
@@ -181,5 +192,3 @@ The MIT License (MIT). Please see [License File](LICENSE.md) for more informatio
 [link-code-quality]: https://scrutinizer-ci.com/g/sitepoint/Rauth
 [link-author]: https://github.com/swader
 [link-docs]: http://readthedocs.org
-
-[nofw]: nofw

--- a/src/Rauth/Exception/AuthException.php
+++ b/src/Rauth/Exception/AuthException.php
@@ -1,0 +1,74 @@
+<?php
+
+namespace SitePoint\Rauth\Exception;
+
+class AuthException extends \Exception
+{
+    private $reasons = [];
+
+    /** @var string */
+    private $type = '';
+
+    public function __construct($type = '')
+    {
+        $this->setType($type);
+    }
+
+    /**
+     * Returns the collection of reasons. Can be empty.
+     *
+     * @return array
+     */
+    public function getReasons() : array
+    {
+        return $this->reasons;
+    }
+
+    /**
+     * Adds a reason to the reason bag in the exception
+     *
+     * @param Reason $reason
+     * @return AuthException
+     */
+    public function addReason(Reason $reason) : AuthException
+    {
+        $this->reasons[] = $reason;
+        return $this;
+    }
+
+    /**
+     * Checks if any reasons have been defined in the exception
+     *
+     * @return bool
+     */
+    public function hasReasons() : bool
+    {
+        return (count($this->reasons) > 0);
+    }
+
+    /**
+     * Sets the context in which the exception was thrown
+     *
+     * Example "ban" or "and"
+     *
+     * @param string $type
+     * @return AuthException
+     */
+    public function setType(string $type) : AuthException
+    {
+        $this->type = $type;
+        return $this;
+    }
+
+    /**
+     * Returns context in which exception occurred.
+     *
+     * Example "ban" or "and"
+     *
+     * @return string
+     */
+    public function getType() : string
+    {
+        return $this->type;
+    }
+}

--- a/src/Rauth/Exception/Reason.php
+++ b/src/Rauth/Exception/Reason.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace SitePoint\Rauth\Exception;
+
+class Reason
+{
+    /** @var string */
+    public $group;
+
+    /** @var array */
+    public $has;
+
+    /** @var array */
+    public $needs;
+
+    /**
+     * Reason constructor.
+     *
+     * Note that the word "group" below does not mean a group the user belongs
+     * to, for example, but a group of attributes required / applied
+     *
+     * @param string $group "Auth-" group that caused the problem
+     * @param array $has Existing attributes in that group
+     * @param array $needs Needed / forbidden attributes in that group
+     */
+    public function __construct(string $group, array $has, array $needs)
+    {
+        $this->group = $group;
+        $this->has = $has;
+        $this->needs = $needs;
+    }
+}

--- a/tests/ExceptionTest.php
+++ b/tests/ExceptionTest.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace SitePoint\Rauth\Tests;
+use SitePoint\Rauth;
+use SitePoint\Rauth\Exception\Reason;
+use SitePoint\Rauth\Exception\AuthException;
+
+class ExceptionTest extends \PHPUnit_Framework_TestCase
+{
+    public function testBanException() {
+        $r = new Rauth;
+        try {
+            $r->authorize(
+                new ExampleClass(), 'anotherTest', ['groups' => 'blocked']
+            );
+        } catch (AuthException $e) {
+            $this->assertTrue($e->hasReasons());
+            $reasons = $e->getReasons();
+            $this->assertEquals(1, count($reasons));
+            $this->assertEquals('ban', $e->getType());
+            /** @var Reason $reason */
+            $reason = $reasons[0];
+            $this->assertEquals('groups', $reason->group);
+        }
+    }
+
+}

--- a/tests/RauthTest.php
+++ b/tests/RauthTest.php
@@ -3,6 +3,8 @@
 namespace SitePoint\Rauth\Tests;
 
 use SitePoint\Rauth;
+use SitePoint\Rauth\Exception\AuthException;
+use SitePoint\Rauth\Exception\Reason;
 
 /**
  * Class RauthTest
@@ -47,8 +49,8 @@ class RauthTest extends \PHPUnit_Framework_TestCase
 
         $set1 = [
             // Class-only tests
-            [$c1, null, [], false], // anon user, class auths, fails
-            [$c1, null, ['groups' => [], 'permissions' => []], false], // weirdly and badly configured user, cannot pass
+            [$c1, null, [], 'exception'], // anon user, class auths, fails
+            [$c1, null, ['groups' => [], 'permissions' => []], 'exception'], // weirdly and badly configured user, cannot pass
             [$c1, null, ['groups' => ['admin']], true], // user with group admin should pass
             [$c1, null, ['permissions' => ['cook', 'clean']], true], // user with these permissions should pass
             [$c1, null, ['permissions' => ['cook', 'kill']], true], // user with these permissions should pass even though one doesn't exist
@@ -57,17 +59,17 @@ class RauthTest extends \PHPUnit_Framework_TestCase
         ];
 
         $method = 'someTest';
-        $set1[] = [$c1, $method, [], false];
-        $set1[] = [$c1, $method, ['groups' => [], 'permissions' => []], false];
-        $set1[] = [$c1, $method, ['groups' => ['admin']], false];
+        $set1[] = [$c1, $method, [], 'exception'];
+        $set1[] = [$c1, $method, ['groups' => [], 'permissions' => []], 'exception'];
+        $set1[] = [$c1, $method, ['groups' => ['admin']], 'exception'];
         $set1[] = [$c1, $method, ['groups' => ['reg-user']], true];
         $set1[] = [$c1, $method, ['groups' => ['paying customers', 'reg-user']], true];
         $set1[] = [$c1, $method, ['groups' => ['paying customers']], true];
         $set1[] = [$c1, $method, ['groups' => 'paying customers'], true];
-        $set1[] = [$c1, $method, ['permissions' => ['cook', 'clean']], false];
-        $set1[] = [$c1, $method, ['permissions' => ['cook', 'kill']], false]; // user with these permissions should pass even though one doesn't exist
-        $set1[] = [$c1, $method, ['permissions' => ['cook', 'kill'], 'banana' => ['yellow']], false]; // made up categories have no effect
-        $set1[] = [$c1, $method, ['groups' => 'admin'], false];
+        $set1[] = [$c1, $method, ['permissions' => ['cook', 'clean']], 'exception'];
+        $set1[] = [$c1, $method, ['permissions' => ['cook', 'kill']], 'exception']; // user with these permissions should pass even though one doesn't exist
+        $set1[] = [$c1, $method, ['permissions' => ['cook', 'kill'], 'banana' => ['yellow']], 'exception']; // made up categories have no effect
+        $set1[] = [$c1, $method, ['groups' => 'admin'], 'exception'];
 
         $method = 'someOtherTest';
         $set1[] = [$c1, $method, [], true];
@@ -76,37 +78,37 @@ class RauthTest extends \PHPUnit_Framework_TestCase
         $set1[] = [$c1, $method, ['groups' => ['reg-user']], true];
         $set1[] = [$c1, $method, ['groups' => ['paying customers', 'reg-user']], true];
         $set1[] = [$c1, $method, ['groups' => ['paying customers']], true];
-        $set1[] = [$c1, $method, ['groups' => ['foo']], false];
-        $set1[] = [$c1, $method, ['groups' => ['foo', 'bar']], false];
+        $set1[] = [$c1, $method, ['groups' => ['foo']], 'exception'];
+        $set1[] = [$c1, $method, ['groups' => ['foo', 'bar']], 'exception'];
         $set1[] = [$c1, $method, ['groups' => 'paying customers'], true];
-        $set1[] = [$c1, $method, ['groups' => 'foo'], false];
+        $set1[] = [$c1, $method, ['groups' => 'foo'], 'exception'];
         $set1[] = [$c1, $method, ['permissions' => ['cook', 'clean']], true];
         $set1[] = [$c1, $method, ['permissions' => ['cook', 'kill']], true]; // user with these permissions should pass even though one doesn't exist
-        $set1[] = [$c1, $method, ['permissions' => ['cook', 'kill'], 'banana' => ['yellow'], 'groups' => 'foo'], false]; // made up categories have no effect
+        $set1[] = [$c1, $method, ['permissions' => ['cook', 'kill'], 'banana' => ['yellow'], 'groups' => 'foo'], 'exception']; // made up categories have no effect
 
         $method = 'anotherTest';
-        $set1[] = [$c1, $method, [], false];
-        $set1[] = [$c1, $method, ['groups' => [], 'permissions' => []], false];
-        $set1[] = [$c1, $method, ['groups' => ['admin']], false];
-        $set1[] = [$c1, $method, ['groups' => ['reg-user']], false];
-        $set1[] = [$c1, $method, ['groups' => ['paying customers', 'reg-user']], false];
-        $set1[] = [$c1, $method, ['groups' => ['paying customers']], false];
-        $set1[] = [$c1, $method, ['groups' => ['foo']], false];
-        $set1[] = [$c1, $method, ['groups' => ['foo', 'bar']], false];
-        $set1[] = [$c1, $method, ['groups' => 'paying customers'], false];
-        $set1[] = [$c1, $method, ['groups' => 'foo'], false];
-        $set1[] = [$c1, $method, ['permissions' => ['cook', 'clean']], false];
-        $set1[] = [$c1, $method, ['permissions' => ['cook', 'kill']], false]; // user with these permissions should pass even though one doesn't exist
-        $set1[] = [$c1, $method, ['permissions' => ['cook', 'kill'], 'banana' => ['yellow'], 'groups' => 'foo'], false]; // made up categories have no effect
+        $set1[] = [$c1, $method, [], 'exception'];
+        $set1[] = [$c1, $method, ['groups' => [], 'permissions' => []], 'exception'];
+        $set1[] = [$c1, $method, ['groups' => ['admin']], 'exception'];
+        $set1[] = [$c1, $method, ['groups' => ['reg-user']], 'exception'];
+        $set1[] = [$c1, $method, ['groups' => ['paying customers', 'reg-user']], 'exception'];
+        $set1[] = [$c1, $method, ['groups' => ['paying customers']], 'exception'];
+        $set1[] = [$c1, $method, ['groups' => ['foo']], 'exception'];
+        $set1[] = [$c1, $method, ['groups' => ['foo', 'bar']], 'exception'];
+        $set1[] = [$c1, $method, ['groups' => 'paying customers'], 'exception'];
+        $set1[] = [$c1, $method, ['groups' => 'foo'], 'exception'];
+        $set1[] = [$c1, $method, ['permissions' => ['cook', 'clean']], 'exception'];
+        $set1[] = [$c1, $method, ['permissions' => ['cook', 'kill']], 'exception']; // user with these permissions should pass even though one doesn't exist
+        $set1[] = [$c1, $method, ['permissions' => ['cook', 'kill'], 'banana' => ['yellow'], 'groups' => 'foo'], 'exception']; // made up categories have no effect
         $set1[] = [$c1, $method, ['banana' => 'whatever', 'name' => 'Bruno'], true];
         $set1[] = [$c1, $method, ['banana' => 'whatever', 'name' => 'Bruno', 'groups' => []], true];
-        $set1[] = [$c1, $method, ['banana' => 'whatever', 'name' => 'Bruno', 'groups' => ['blocked']], false];
-        $set1[] = [$c1, $method, ['name' => 'Bruno', 'groups' => []], false];
-        $set1[] = [$c1, $method, ['banana' => 'whatever', 'groups' => []], false];
+        $set1[] = [$c1, $method, ['banana' => 'whatever', 'name' => 'Bruno', 'groups' => ['blocked']], 'exception'];
+        $set1[] = [$c1, $method, ['name' => 'Bruno', 'groups' => []], 'exception'];
+        $set1[] = [$c1, $method, ['banana' => 'whatever', 'groups' => []], 'exception'];
         
         $method = 'noAuthTest';
-        $set1[] = [$c1, $method, [], false];
-        $set1[] = [$c1, $method, ['groups' => [], 'permissions' => []], false];
+        $set1[] = [$c1, $method, [], 'exception'];
+        $set1[] = [$c1, $method, ['groups' => [], 'permissions' => []], 'exception'];
         $set1[] = [$c1, $method, ['groups' => ['admin']], true];
         $set1[] = [$c1, $method, ['permissions' => ['cook', 'clean']], true];
         $set1[] = [$c1, $method, ['permissions' => ['cook', 'kill']], true];
@@ -114,8 +116,8 @@ class RauthTest extends \PHPUnit_Framework_TestCase
         $set1[] = [$c1, $method, ['groups' => 'admin'], true];
 
         $method = 'noDocblockTest';
-        $set1[] = [$c1, $method, [], false];
-        $set1[] = [$c1, $method, ['groups' => [], 'permissions' => []], false];
+        $set1[] = [$c1, $method, [], 'exception'];
+        $set1[] = [$c1, $method, ['groups' => [], 'permissions' => []], 'exception'];
         $set1[] = [$c1, $method, ['groups' => ['admin']], true];
         $set1[] = [$c1, $method, ['permissions' => ['cook', 'clean']], true];
         $set1[] = [$c1, $method, ['permissions' => ['cook', 'kill']], true];
@@ -143,9 +145,21 @@ class RauthTest extends \PHPUnit_Framework_TestCase
     public function testAuthorizeDefault($class, $method, $attributes, $success)
     {
         $r = new Rauth();
-        $this->assertTrue(
-            $r->authorize($class, $method, $attributes) === $success
-        );
+        if (is_bool($success)) {
+            $this->assertTrue(
+                $r->authorize($class, $method, $attributes) === $success
+            );
+        } else {
+            try {
+                $r->authorize($class, $method, $attributes);
+                $this->fail('AuthException not caught');
+            } catch (AuthException $e) {
+                $mode = $r->extractAuth($class, $method)['mode'] ?? Rauth::MODE_OR;
+                $this->assertTrue(in_array($e->getType(), ['ban', $mode]));
+                //dump($e->getType());
+                //dump($e->getReasons());
+            }
+        }
     }
 
     public function testInvalidMode()


### PR DESCRIPTION
Instead of returning false, the `authorize` method now throws an exception when authorization fails.

This `AuthException` contains a property `type` which indicates the type of the exception (`ban`, `and`, `or`, `none`, or any custom mode that can later be added in) and an array of Reason objects each of which contains the public properties `group`, `has` and `needs`. See README for more information about these changes.
